### PR TITLE
Hot fix: script crashes on currently kicad dev version

### DIFF
--- a/pcb2blender_exporter/export.py
+++ b/pcb2blender_exporter/export.py
@@ -41,7 +41,8 @@ def export_pcb3d(filepath, boarddefs):
 
     layers_path = get_temppath(LAYERS)
     board = pcbnew.GetBoard()
-    bounds = tuple(map(ToMM, board.ComputeBoundingBox(aBoardEdgesOnly=True).getWxRect()))
+    bbox = board.ComputeBoundingBox(aBoardEdgesOnly=True)
+    bounds = tuple(map(ToMM, (bbox.GetTop(), bbox.GetLeft(), bbox.GetBottom(), bbox.GetRight())))
     bounds = (
         bounds[0] - SVG_MARGIN, bounds[1] - SVG_MARGIN,
         bounds[2] + SVG_MARGIN * 2, bounds[3] + SVG_MARGIN * 2
@@ -149,7 +150,6 @@ def export_layers(board, bounds, output_directory):
     plot_options.SetScale(1)
     plot_options.SetMirror(False)
     plot_options.SetUseGerberAttributes(True)
-    plot_options.SetExcludeEdgeLayer(True)
     plot_options.SetDrillMarksType(PCB_PLOT_PARAMS.NO_DRILL_SHAPE)
 
     for layer in INCLUDED_LAYERS:


### PR DESCRIPTION
KiCad info:
```
Application: KiCad
Version: (6.99.0-3211-g2d203bc975), release build
Libraries:
    wxWidgets 3.2
    FreeType 2.12.1
    HarfBuzz 5.1.0
    FontConfig 2.14.0
    libcurl/7.85.0 OpenSSL/1.1.1q zlib/1.2.12 brotli/1.0.9 zstd/1.5.2 libidn2/2.3.3 libpsl/0.21.1 (+libidn2/2.3.0) libssh2/1.10.0 nghttp2/1.49.0
Platform: Linux 5.19.6-hardened1-1-hardened x86_64, 64 bit, Little endian, wxGTK, KDE, x11
Build Info:
    Date: Sep 4 2022 04:40:24
    wxWidgets: 3.2.0 (wchar_t,wx containers) GTK+ 3.24
    Boost: 1.79.0
    OCC: 7.5.3
    Curl: 7.85.0
    ngspice: 37
    Compiler: GCC 12.2.0 with C++ ABI 1017
Build settings:
    KICAD_USE_EGL=ON
    KICAD_SPICE=ON
```
this script throws some exceptions before:
![图片](https://user-images.githubusercontent.com/55868015/192126972-8185cc49-260a-4f33-8499-42c99d6087b4.png)
![图片](https://user-images.githubusercontent.com/55868015/192127029-36572867-2473-460d-846a-351126b2183e.png)

so there is a hot fix for them