### PR TITLE
Derive SMOOTH_BY_ANGLE_ASSET_PATH from system resource path

### DIFF
--- a/pcb2blender_importer/importer.py
+++ b/pcb2blender_importer/importer.py
@@ -1084,7 +1084,7 @@ class PCB2BLENDER_PT_import_transform_x3d(X3D_PT_import_transform_copy):
     def poll(cls, context):
         return context.space_data.active_operator.bl_idname == "PCB2BLENDER_OT_import_x3d"
 
-RESOURCE_PATH = Path(bpy.utils.resource_path("LOCAL"))
+RESOURCE_PATH = Path(bpy.utils.resource_path("SYSTEM"))
 SMOOTH_BY_ANGLE_ASSET_PATH = str(
     RESOURCE_PATH / "datafiles" / "assets" / "geometry_nodes" / "smooth_by_angle.blend"
 )


### PR DESCRIPTION
Hi, I'm running Arch Linux with Blender 4.1 and KiCad 7, installed from the main package repositories and I've installed the pcb2blender 2.1 release per the readme.

I am encountering an error in [importer.py](https://github.com/30350n/pcb2blender/blob/master/pcb2blender_importer/importer.py) when resolving smooth_by_angle.blend:

![image](https://github.com/30350n/pcb2blender/assets/1273851/5f8c9b26-df6b-426c-b4ac-fd008ec26f40)

Calling bpy.utils.resource_path() with "SYSTEM" as the argument instead of "LOCAL" fixes the issue for me.

❌ Path(bpy.utils.resource_path("LOCAL")) resolves to /usr/bin
✅ Path(bpy.utils.resource_path("SYSTEM")) resolves to /usr/share/blender

Thanks! ⭐🌈