### PR TITLE
Fix #68 (tmp project becomes default)

### DIFF
--- a/pcb2blender_exporter/export.py
+++ b/pcb2blender_exporter/export.py
@@ -214,7 +214,8 @@ def get_stackup(board):
     stackup = Stackup()
 
     tmp_path = get_temppath("pcb2blender_tmp.kicad_pcb")
-    board.Save(str(tmp_path))
+    # aSkipSettings=True to inhibit updating the recent projects list.
+    pcbnew.SaveBoard(str(tmp_path), board, True)
     content = tmp_path.read_text(encoding="utf-8")
 
     if not (match := stackup_regex.search(content)):

--- a/pcb2blender_exporter/export.py
+++ b/pcb2blender_exporter/export.py
@@ -214,8 +214,7 @@ def get_stackup(board):
     stackup = Stackup()
 
     tmp_path = get_temppath("pcb2blender_tmp.kicad_pcb")
-    # aSkipSettings=True to inhibit updating the recent projects list.
-    pcbnew.SaveBoard(str(tmp_path), board, True)
+    pcbnew.SaveBoard(str(tmp_path), board, aSkipSettings=True)
     content = tmp_path.read_text(encoding="utf-8")
 
     if not (match := stackup_regex.search(content)):


### PR DESCRIPTION
Change method of creating tmp project from `board.Save` to `pcbnew.SaveBoard` so `aSkipSettings` can be set to `True`. The code path is the same, ultimately, but with `aSkipSettings` set to `True` the bit where `SETTINGS_MANAGER` is invoked to "Set the currently loaded project path and save it" is skipped. The net effect is that file save is the same, but the user's recent projects history is not changed. So the tmp project does not appear in the "Open Recent" list in the File menu, and KiCad does not restart with the tmp project by default.